### PR TITLE
CI: Add a default permissions block for the CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,18 +47,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Install stable Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        id: rust-toolchain
 
-      - uses: Swatinem/rust-cache@v2
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5
 
-      - name: Install zizmor
-        run: |
-          cargo install zizmor
-
-      - name: zizmor - GitHub actions audit
-        run: zizmor .
+      - name: Run zizmor 🌈
+        run: uvx zizmor .
 
   test:
     name: Unit tests


### PR DESCRIPTION
The permissions map controls what the GITHUB_TOKEN can do in a job. By
default, set the permissions so that jobs can read contents and nothing
else.

This was called out by zizmor.