### PR TITLE
docs: check in the manual and add CI to ensure its up-to-date

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,6 +101,9 @@ jobs:
       - name: Run unit tests
         run: cargo test --all-features --workspace --no-fail-fast --bins --examples --benches
 
+      - name: Check manual is up-to-date
+        run: cargo xtask manual && test -z "$(git status --porcelain)"
+
   integration-tests:
     name: Integration tests
     runs-on: ubuntu-latest

--- a/sigul-pesign-bridge/docs/sigul-pesign-bridge.1
+++ b/sigul-pesign-bridge/docs/sigul-pesign-bridge.1
@@ -1,0 +1,50 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH sigul-pesign-bridge 1  "sigul-pesign-bridge 0.2.0" 
+.SH NAME
+sigul\-pesign\-bridge \- An alternative to the pesign daemon interface
+.SH SYNOPSIS
+\fBsigul\-pesign\-bridge\fR [\fB\-c\fR|\fB\-\-config\fR] [\fB\-\-log\-filter\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIsubcommands\fR>
+.SH DESCRIPTION
+An alternative to the pesign daemon interface.
+.PP
+The Unix socket this service offers can be used by pesign\-client. Rather than signing the PE file, however, this application will act as a sigul client and forward it to a sigul signing server.
+.PP
+Log configuration is provided using the "SIGUL_PESIGN_BRIDGE_LOG" environment variable with one or more comma\-separated directives. In short, filters can be plain verbosity levels ("trace", "debug", "info", "warn", "error"), or more complex filtering at the model, span, or event level.
+.SH OPTIONS
+.TP
+\fB\-c\fR, \fB\-\-config\fR=\fICONFIG\fR
+Path to the configuration file.
+
+If no path is provided, the defaults are used. To view the service defaults, run the `config` subcommand.
+.RS
+May also be specified with the \fBSIGUL_PESIGN_BRIDGE_CONFIG\fR environment variable. 
+.RE
+.TP
+\fB\-\-log\-filter\fR=\fILOG_FILTER\fR [default: WARN,sigul_pesign_bridge=INFO]
+A set of one or more comma\-separated directives to filter logs.
+
+The general format is "target_name[span_name{field=value}]=level" where level is one of TRACE, DEBUG, INFO, WARN, ERROR.
+
+Details: https://docs.rs/tracing\-subscriber/0.3.19/tracing_subscriber/filter/struct.EnvFilter.html#directives
+.RS
+May also be specified with the \fBSIGUL_PESIGN_BRIDGE_LOG\fR environment variable. 
+.RE
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version
+.SH SUBCOMMANDS
+.TP
+sigul\-pesign\-bridge\-listen(1)
+Run the service
+.TP
+sigul\-pesign\-bridge\-config(1)
+Print the current service configuration to standard output
+.TP
+sigul\-pesign\-bridge\-help(1)
+Print this message or the help of the given subcommand(s)
+.SH VERSION
+v0.2.0

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -34,7 +34,10 @@ fn main() -> anyhow::Result<()> {
 }
 
 fn generate_manual() -> anyhow::Result<()> {
-    let outdir = PathBuf::from(env::var_os("OUT_DIR").ok_or(anyhow!("Must set OUT_DIR"))?);
+    let mut root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    root.push("../");
+
+    let outdir = root.join("sigul-pesign-bridge/docs/");
     let command = sigul_pesign_bridge::cli::Cli::command();
     let manual = clap_mangen::Man::new(command);
     manual.generate_to(outdir)?;


### PR DESCRIPTION
This makes it slightly easier to package since we don't need to build the manual.