### PR TITLE
CI: Test against a sigul server backed by softhsm

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,7 +115,7 @@ jobs:
           RUN_SIGUL_BRIDGE: true
         volumes:
           - ./devel/github:/etc/sigul
-          
+
       sigul-server:
         image: quay.io/jeremycline/sigul-pesign-bridge-ci:latest
         env:
@@ -138,12 +138,13 @@ jobs:
           # GitHub actions occasionally hangs here; I've not seen it locally and my theory
           # is sigul takes a bit of time to come up and doesn't do retries well at all.
           sleep 5
-          bash ./devel/sigul_key_setup.sh
 
           # More hackiness; copy the test PE and signing certificates to the location
           # it would be at if we had built it rather than baking it into the image.
           # GitHub Actions does not use the container's WORKDIR.
           cp -r /srv/siguldry/* .
+          mkdir keys/
+          cp *.pem keys/
 
           mkdir -p /run/pesign/
 

--- a/devel/Containerfile.sigul
+++ b/devel/Containerfile.sigul
@@ -13,26 +13,25 @@ FROM quay.io/almalinuxorg/almalinux:9
 
 RUN dnf install -y epel-release
 RUN dnf install -y \
+    cargo \
+    gcc \
+    iproute \
+    nss-tools \
+    opensc \
+    openssl-pkcs11 \
+    patch \
+    pesign \
+    python3-devel \
+    python3-pip \
+    rpm-devel \
+    sbsigntools \
     sigul \
     sigul-bridge \
     sigul-server \
-    pesign \
-    patch \
-    python3-pip \
-    python3-devel \
-    rpm-devel \
-    gcc \
-    cargo \
-    sbsigntools \
-    iproute
+    softhsm
 
 # Not packaged for fedora, needed for the server. Requires pip and gcc
 RUN pip install rpm-head-signing
-
-# Fix pesign in Sigul
-RUN curl -sL \
-	https://pagure.io/fork/jcline/sigul/c/5b160415b77d40ea80aeb9d9eb1a8c9ec6cf1926.patch \
-	| patch /usr/share/sigul/server.py
 
 RUN mkdir -p /srv/siguldry && chown sigul:sigul /srv/siguldry
 WORKDIR /srv/siguldry
@@ -57,6 +56,7 @@ COPY devel/local/client.conf /etc/sigul/client.conf
 COPY devel/github /etc/sigul-pesign-bridge-ci
 COPY devel/sigul_key_setup.sh /usr/local/bin/sigul_key_setup
 COPY devel/startup_wrapper.sh /usr/local/bin/sigul_wrapper
+COPY devel/setup_hsm.sh /usr/local/bin/setup_hsm
 
 # It's a gross little hack, but we copy in the example PE executable rather than dealing
 # with not having rustup in EL9 repos and getting additional targets installed.
@@ -65,10 +65,24 @@ COPY devel/startup_wrapper.sh /usr/local/bin/sigul_wrapper
 RUN mkdir -p target/x86_64-unknown-uefi/debug/
 COPY target/x86_64-unknown-uefi/debug/sample-uefi.efi target/x86_64-unknown-uefi/debug/sample-uefi.efi
 
+# Fix pesign in Sigul
+RUN curl -sL \
+	https://pagure.io/fork/jcline/sigul/c/5b160415b77d40ea80aeb9d9eb1a8c9ec6cf1926.patch \
+	| patch /usr/share/sigul/server.py
+
+# Support PKCS11 signing
+RUN curl -sL \
+	https://pagure.io/fork/jcline/sigul/c/d70285810c63f6e136f70fb13a4b6323f9db3db1.patch \
+	| patch -d /usr/share/sigul/ && \
+	chmod +x /usr/share/sigul/server_add_pkcs11_token.py
+
 RUN sigul_server_create_db
 # The nss password needs to be in the sigul-server.conf since it's sourced from there
 RUN printf "my-admin-password\0" | sigul_server_add_admin --batch --name=sigul-client
 RUN mkdir ~/.sigul/ && cp -r /var/lib/sigul ~/.sigul/sigul
+
+# Set up a software HSM with Secure Boot keys to use in the Sigul server
+RUN setup_hsm
 
 # A hacky work-around for GitHub actions not letting you specify the entrypoint for a container
 ENTRYPOINT /usr/local/bin/sigul_wrapper

--- a/devel/local_hsm_test.sh
+++ b/devel/local_hsm_test.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+# Create a new softhsm2 token, create some keys and certificates within the token
+# and interact with them via NSS and openssl.
+#
+# In a Fedora 41 environment:
+#
+# $ dnf install softhsm opensc nss-tools openssl p11-kit pkcs11-provider sbsigntools
+#
+# Example:
+#   $ pushd sample-uefi && cargo build && popd
+#   $ ./devel/local_hsm_test.sh target/x86_64-unknown-uefi/debug/sample-uefi.efi
+
+set -xeuo pipefail
+
+UNSIGNED_EFI=$1
+
+BASE_NAME=$(basename "$UNSIGNED_EFI")
+TMPDIR=$(mktemp -d)
+cp "$UNSIGNED_EFI" "$TMPDIR/$BASE_NAME"
+UNSIGNED_EFI="$TMPDIR/$BASE_NAME"
+pushd "$TMPDIR"
+
+mkdir -p softhsm2/tokens/
+cat > softhsm2/softhsm2.conf << EOF
+# SoftHSM v2 configuration file
+directories.tokendir = $PWD/softhsm2/tokens/
+objectstore.backend = file
+# ERROR, WARNING, INFO, DEBUG
+log.level = INFO
+# If CKF_REMOVABLE_DEVICE flag should be set
+slots.removable = false
+# Enable and disable PKCS#11 mechanisms using slots.mechanisms.
+slots.mechanisms = ALL
+# If the library should reset the state on fork
+library.reset_on_fork = false
+EOF
+export SOFTHSM2_CONF="$PWD/softhsm2/softhsm2.conf"
+
+HSM_PIN="abc123def"
+HSM_SO_PIN="fed321cba"
+NSS_DB_PASSWORD="secret"
+TOKEN_LABEL="Sigul Token 0"
+
+# Initialize a token slot in softhsm
+softhsm2-util \
+	--init-token --slot 0 --label "$TOKEN_LABEL" \
+	--pin "$HSM_PIN" --so-pin "$HSM_SO_PIN"
+SLOT_URI=$(p11-kit list-modules | grep "^\s*uri:.*token=Sigul" | awk '{ print $2 }')
+# Make a keypair for a CA and for code signing
+pkcs11-tool --module /usr/lib64/softhsm/libsofthsm.so \
+	--login --pin "$HSM_PIN" \
+	--keypairgen --label="Secure Boot CA" \
+	--key-type rsa:2048 --usage-sig --id 1
+pkcs11-tool --module /usr/lib64/softhsm/libsofthsm.so \
+	--login --pin "$HSM_PIN" \
+	--keypairgen --label="Secure Boot Code Signing" \
+	--key-type rsa:2048 --usage-sig --id 2
+
+# Generate certificates for the above key pairs
+cat > openssl.cnf << EOF
+[code_signing_exts]
+keyUsage = digitalSignature
+extendedKeyUsage = codeSigning
+EOF
+printf "%s\n" "$HSM_PIN" > hsm_pin
+openssl req -passin file:./hsm_pin -new -x509 -days 3650 -sha256 -extensions v3_ca \
+	-subj "/CN=Secure Boot CA" -provider pkcs11 \
+	-key "${SLOT_URI};object=Secure%20Boot%20CA;type=private" \
+	-out secure-boot-ca-cert.pem
+openssl req -passin file:./hsm_pin -config ./openssl.cnf -new -sha256 -extensions code_signing_exts \
+	-subj "/CN=Secure Boot Code Signing" -provider pkcs11 \
+	-key "${SLOT_URI};object=Secure%20Boot%20Code%20Signing;type=private" \
+	-out secure-boot-code-signing.csr
+openssl x509 -passin file:./hsm_pin -req -provider pkcs11 -in secure-boot-code-signing.csr \
+	-extfile openssl.cnf -extensions code_signing_exts \
+	-CAkey "${SLOT_URI};object=Secure%20Boot%20CA;type=private" \
+	-CA ./secure-boot-ca-cert.pem -days 365 -sha256 \
+	-out secure-boot-code-signing-cert.pem
+
+# Do they seem reasonable?
+openssl verify -CAfile secure-boot-ca-cert.pem secure-boot-ca-cert.pem
+openssl verify -CAfile secure-boot-ca-cert.pem secure-boot-code-signing-cert.pem
+
+# Write the certificates to the token
+pkcs11-tool --module /usr/lib64/softhsm/libsofthsm.so \
+	--login --pin "$HSM_PIN" \
+	--write-object secure-boot-ca-cert.pem \
+	--type cert --label "Secure Boot CA Certificate" --id 1
+pkcs11-tool --module /usr/lib64/softhsm/libsofthsm.so \
+	--login --pin "$HSM_PIN" \
+	--write-object secure-boot-code-signing-cert.pem \
+	--type cert --label "Secure Boot Code Signing Certificate" --id 2
+
+mkdir nss
+printf "%s\n" "$NSS_DB_PASSWORD" > nss_pwfile
+certutil -d nss -N -f ./nss_pwfile
+# It knows about the SoftHSM token via p11-kit
+certutil -d nss -U
+# It knows about the keys and certificates
+certutil -d nss -h "$TOKEN_LABEL" -f ./hsm_pin -L
+certutil -d nss -h "$TOKEN_LABEL" -f ./hsm_pin -K
+
+# This works
+pesign -i "$UNSIGNED_EFI" -E sample-uefi.sattrs.bin
+openssl dgst -passin file:./hsm_pin -sha256 \
+	-sign "${SLOT_URI};object=Secure%20Boot%20Code%20Signing;type=private" \
+	-provider pkcs11 -out sample-uefi.sattrs.sig sample-uefi.sattrs.bin
+certutil -d nss -A -f ./nss_pwfile -n secure-boot-code-signer -t ,,u -i secure-boot-code-signing-cert.pem
+pesign -n nss -c "secure-boot-code-signer" \
+	-R sample-uefi.sattrs.sig -I sample-uefi.sattrs.bin \
+	--pinfile=./nss_pwfile \
+	-i "$UNSIGNED_EFI" \
+	-o signed.efi
+sbverify --cert secure-boot-code-signing-cert.pem signed.efi
+sbverify --cert secure-boot-ca-cert.pem signed.efi
+
+# So does this
+pesign -n nss \
+	-t "Sigul Token 0" \
+	-c "Secure Boot Code Signing Certificate" \
+	--pinfile=./hsm_pin \
+	-s \
+	-i "$UNSIGNED_EFI" \
+	-o signed2.efi
+sbverify --cert secure-boot-code-signing-cert.pem signed2.efi
+sbverify --cert secure-boot-ca-cert.pem signed2.efi

--- a/devel/setup_hsm.sh
+++ b/devel/setup_hsm.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Sets up a softhsm2 PKCS11 token for the CI image; this is designed to work with
+# an EL9 system and does _not_ work with modern versions of openssl on Fedora, as
+# the openssl engine API is disabled. Refer to local_hsm_test.sh for a more
+# complete script which used the provider API, that works on Fedora (and EL10+)
+# and demonstrates how to sign via pesign directly and via openssl dgst.
+#
+# In an EL9 environment:
+#
+# $ dnf install epel-release  # for sbsigntools
+# $ dnf install softhsm opensc nss-tools openssl p11-kit openssl-pkcs11 sbsigntools
+
+set -xeuo pipefail
+
+HSM_PIN="abc123def"
+HSM_SO_PIN="fed321cba"
+TOKEN_LABEL="Sigul Token 0"
+
+# Initialize a token slot in softhsm
+softhsm2-util \
+	--init-token --slot 0 --label "$TOKEN_LABEL" \
+	--pin "$HSM_PIN" --so-pin "$HSM_SO_PIN"
+# Make a keypair for a CA and for code signing
+pkcs11-tool --module /usr/lib64/softhsm/libsofthsm.so \
+	--login --pin "$HSM_PIN" \
+	--keypairgen --label="Secure Boot CA" \
+	--key-type rsa:2048 --usage-sig --id 1
+pkcs11-tool --module /usr/lib64/softhsm/libsofthsm.so \
+	--login --pin "$HSM_PIN" \
+	--keypairgen --label="Secure Boot Code Signing" \
+	--key-type rsa:2048 --usage-sig --id 2
+
+SLOT_URI=$(p11-kit list-modules | grep "^\s*uri:.*token=Sigul" | awk '{ print $2 }')
+SIGNING_KEY_URI="${SLOT_URI};object=Secure%20Boot%20Code%20Signing;type=private"
+
+# Generate certificates for the above key pairs
+cat > openssl.cnf << EOF
+[code_signing_exts]
+keyUsage = digitalSignature
+extendedKeyUsage = codeSigning
+EOF
+printf "%s\n" "$HSM_PIN" > hsm_pin
+openssl req -passin file:./hsm_pin -new -x509 -days 3650 -sha256 -extensions v3_ca \
+	-subj "/CN=Secure Boot CA" -engine pkcs11 -keyform engine \
+	-key "${SLOT_URI};object=Secure%20Boot%20CA;type=private" \
+	-out secure-boot-ca-cert.pem
+openssl req -passin file:./hsm_pin -config ./openssl.cnf -new -sha256 -extensions code_signing_exts \
+	-subj "/CN=Secure Boot Code Signing" -engine pkcs11 -keyform engine \
+	-key "${SLOT_URI};object=Secure%20Boot%20Code%20Signing;type=private" \
+	-out secure-boot-code-signing.csr
+openssl x509 -passin file:./hsm_pin -req -engine pkcs11 -CAkeyform engine \
+	-in secure-boot-code-signing.csr \
+	-extfile openssl.cnf -extensions code_signing_exts \
+	-CAkey "${SLOT_URI};object=Secure%20Boot%20CA;type=private" \
+	-CA ./secure-boot-ca-cert.pem -days 365 -sha256 \
+	-out secure-boot-code-signing-cert.pem
+
+# Do they seem reasonable?
+openssl verify -CAfile secure-boot-ca-cert.pem secure-boot-ca-cert.pem
+openssl verify -CAfile secure-boot-ca-cert.pem secure-boot-code-signing-cert.pem
+
+# Write the certificates to the token
+pkcs11-tool --module /usr/lib64/softhsm/libsofthsm.so \
+	--login --pin "$HSM_PIN" \
+	--write-object secure-boot-ca-cert.pem \
+	--type cert --label "Secure Boot CA Certificate" --id 1
+pkcs11-tool --module /usr/lib64/softhsm/libsofthsm.so \
+	--login --pin "$HSM_PIN" \
+	--write-object secure-boot-code-signing-cert.pem \
+	--type cert --label "Secure Boot Code Signing Certificate" --id 2
+
+# The sigul user needs to be able to own the token
+chown -R sigul:sigul /var/lib/softhsm/
+
+echo "my-signing-password" > passphrase_file
+/usr/share/sigul/server_add_pkcs11_token.py --initial-key-admin sigul-client \
+	--key-uri "${SIGNING_KEY_URI}" \
+	--key-name "Sigul HSM Key" \
+	--token-pin-file ./hsm_pin \
+	--passphrase-file ./passphrase_file

--- a/sigul-pesign-bridge/tests/pesign_client.rs
+++ b/sigul-pesign-bridge/tests/pesign_client.rs
@@ -47,7 +47,7 @@ fn run_command(mut client_command: Command) -> Result<(Output, Output)> {
     };
 
     let mut signing_cert = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    signing_cert.push("../keys/signing-cert.pem");
+    signing_cert.push("../keys/secure-boot-code-signing-cert.pem");
     let mut config_file = tempfile::NamedTempFile::new()?;
     let config = format!(
         "
@@ -55,8 +55,8 @@ fn run_command(mut client_command: Command) -> Result<(Output, Output)> {
     request_timeout_secs = 30
 
     [[keys]]
-    key_name = \"signing-key\"
-    certificate_name = \"codesigning\"
+    key_name = \"Sigul HSM Key\"
+    certificate_name = \"Secure Boot Code Signing Certificate\"
     passphrase_path = \"sigul-signing-key-passphrase\"
     certificate_file = \"{}\"
     ",
@@ -125,8 +125,8 @@ fn sign_attached() -> Result<()> {
     let mut client_command = Command::new("pesign-client");
     client_command
         .arg("--sign")
-        .arg("--token=signing-key")
-        .arg("--certificate=codesigning")
+        .arg("--token=Sigul HSM Key")
+        .arg("--certificate=Secure Boot Code Signing Certificate")
         .arg(format!("--infile={}", in_file.as_path().display()))
         .arg(format!("--outfile={}", &out_file.as_path().display()));
     let (client_output, service_output) = run_command(client_command)?;
@@ -154,7 +154,7 @@ fn sign_attached() -> Result<()> {
     );
 
     let mut signing_cert = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    signing_cert.push("../keys/signing-cert.pem");
+    signing_cert.push("../keys/secure-boot-code-signing-cert.pem");
     let output_signed = Command::new("sbverify")
         .arg("--cert")
         .arg(&signing_cert)


### PR DESCRIPTION
This sets up a software HSM in order to test the complete workflow with Sigul using the PKCS#11 interface to access the HSM when signing the EFI application.