### PR TITLE
Add gitleaks rule to ignore CI test key

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,10 @@
+title = "Gitleaks config to ignore test keys"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Ignore private keys extracted from the CI test image"
+paths = [
+	"devel/creds/sigul.client.private_key.pem",
+]


### PR DESCRIPTION
Fedora infra repos get scanned with gitleaks; this private key is not a secret, it's baked into the CI image and checked into the repo to make testing easy. Configure gitleaks to ignore the client private key.