### PR TITLE
client: support the 'user-info' client command

### DIFF
--- a/siguldry/src/bin/siguldry-client/main.rs
+++ b/siguldry/src/bin/siguldry-client/main.rs
@@ -45,6 +45,16 @@ enum Command {
         #[arg(long)]
         admin_passphrase: PathBuf,
     },
+    /// Show information about a user.
+    ///
+    /// The only information available is whether or not the user is an administrator.
+    UserInfo {
+        #[arg(long)]
+        admin_passphrase: PathBuf,
+        /// The name of the user to look up.
+        #[arg(long)]
+        name: String,
+    },
     SignPe {
         #[arg(long)]
         input: PathBuf,
@@ -103,6 +113,18 @@ async fn main() -> anyhow::Result<()> {
             for user in users {
                 println!("{}", user);
             }
+        }
+        Command::UserInfo {
+            admin_passphrase,
+            name,
+        } => {
+            let user = tokio::time::timeout(
+                Duration::from_secs(30),
+                client.get_user(admin_passphrase.as_path().try_into()?, name),
+            )
+            .await
+            .context("request timed out")??;
+            println!("Administrator: {}", if user.admin() { "yes" } else { "no" });
         }
         Command::SignPe {
             input,

--- a/siguldry/tests/client.rs
+++ b/siguldry/tests/client.rs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) Microsoft Corporation.
+//
+// Integration tests for the siguldry client.
+//
+// These tests are expected to work against sigul v1.3+.
+
+use std::path::PathBuf;
+
+use siguldry::error::{ClientError, ConnectionError, Sigul};
+
+fn get_client() -> siguldry::client::Client {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../")
+        .canonicalize()
+        .unwrap();
+    let creds_directory = repo_root.join("devel/creds/");
+    let tls_config = siguldry::client::TlsConfig::new(
+        creds_directory.join("sigul.client.certificate.pem"),
+        creds_directory.join("sigul.client.private_key.pem"),
+        None,
+        creds_directory.join("sigul.ca_certificate.pem"),
+    )
+    .unwrap();
+    let ci = std::env::var("GITHUB_ACTIONS").is_ok_and(|val| val.contains("true"));
+    siguldry::client::Client::new(
+        tls_config,
+        if ci {
+            "sigul-bridge".into()
+        } else {
+            "localhost".into()
+        },
+        44334,
+        if ci {
+            "sigul-server".into()
+        } else {
+            "localhost".into()
+        },
+        "sigul-client".into(),
+    )
+}
+
+#[tokio::test]
+async fn list_users() -> anyhow::Result<()> {
+    let client = get_client();
+    let users = client.users("my-admin-password".into()).await?;
+
+    assert_eq!(users, vec!["sigul-client"]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_user() -> anyhow::Result<()> {
+    let client = get_client();
+    let user = client
+        .get_user("my-admin-password".into(), "sigul-client".to_string())
+        .await?;
+
+    assert!(user.admin());
+    assert_eq!(user.name(), "sigul-client");
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_user_does_not_exist() -> anyhow::Result<()> {
+    let client = get_client();
+    let user = client
+        .get_user("my-admin-password".into(), "not-sigul-client".to_string())
+        .await;
+    if let Err(ClientError::Connection(ConnectionError::Sigul(Sigul::UserNotFound))) = user {
+        // This is obviously a terrible error structure
+    } else {
+        panic!("Expected a Sigul error, got {:?}", user)
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_user_invalid_password() -> anyhow::Result<()> {
+    let client = get_client();
+    let user = client
+        .get_user("not-my-admin-password".into(), "sigul-client".to_string())
+        .await;
+    if let Err(ClientError::Connection(ConnectionError::Sigul(Sigul::AuthenticationFailed))) = user
+    {
+        // This is obviously a terrible error structure
+    } else {
+        panic!("Expected a Sigul error, got {:?}", user)
+    }
+    Ok(())
+}


### PR DESCRIPTION
The server supports querying a given username for information. The only information it returns is whether or not the user is an administrator.

An initial implementation for the CLI is also included, and its output matches the existing Python client. Like the rest of the current CLI, it needs more polish (and tests).