### PR TITLE
ci: pin container version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,18 +106,18 @@ jobs:
 
   integration-tests:
     name: Integration tests
-    runs-on: ubuntu-latest
-    container: quay.io/jeremycline/sigul-pesign-bridge-ci:latest
+    runs-on: ubuntu-22.04
+    container: quay.io/jeremycline/sigul-pesign-bridge-ci:2025-04-24
     services:
       sigul-bridge:
-        image: quay.io/jeremycline/sigul-pesign-bridge-ci:latest
+        image: quay.io/jeremycline/sigul-pesign-bridge-ci:2025-04-24
         env:
           RUN_SIGUL_BRIDGE: true
         volumes:
           - ./devel/github:/etc/sigul
 
       sigul-server:
-        image: quay.io/jeremycline/sigul-pesign-bridge-ci:latest
+        image: quay.io/jeremycline/sigul-pesign-bridge-ci:2025-04-24
         env:
           RUN_SIGUL_SERVER: true
         volumes:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,7 +106,7 @@ jobs:
 
   integration-tests:
     name: Integration tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: quay.io/jeremycline/sigul-pesign-bridge-ci:2025-04-24
     services:
       sigul-bridge:
@@ -115,6 +115,11 @@ jobs:
           RUN_SIGUL_BRIDGE: true
         volumes:
           - ./devel/github:/etc/sigul
+        options: >-
+          --health-cmd "ss -o state established '( sport = :44333 )' && ss -lnt '( sport = :44334 )'"
+          --health-timeout 3s
+          --health-interval 5s
+          --health-retries 5
 
       sigul-server:
         image: quay.io/jeremycline/sigul-pesign-bridge-ci:2025-04-24
@@ -122,6 +127,11 @@ jobs:
           RUN_SIGUL_SERVER: true
         volumes:
           - ./devel/github:/etc/sigul
+        options: >-
+          --health-cmd "ss -tn -o state established '( dport = :44333 )'"
+          --health-timeout 3s
+          --health-interval 5s
+          --health-retries 5
 
     steps:
       - uses: actions/checkout@v4

--- a/compose.yml
+++ b/compose.yml
@@ -1,13 +1,13 @@
 services:
   sigul-bridge:
-    image: quay.io/jeremycline/sigul-pesign-bridge-ci:latest
+    image: quay.io/jeremycline/sigul-pesign-bridge-ci:2025-04-24
     environment:
       RUN_SIGUL_BRIDGE: true
     network_mode: host
     volumes:
       - ./devel/local:/etc/sigul:z
   sigul-server:
-    image: quay.io/jeremycline/sigul-pesign-bridge-ci:latest
+    image: quay.io/jeremycline/sigul-pesign-bridge-ci:2025-04-24
     environment:
       RUN_SIGUL_SERVER: true
     network_mode: host

--- a/siguldry/src/connection.rs
+++ b/siguldry/src/connection.rs
@@ -226,11 +226,16 @@ pub(crate) struct InnerConnection {
 impl Connection<state::New> {
     /// Open a new connection to the Sigul bridge.
     #[instrument(err, skip_all)]
-    pub async fn connect<A: ToSocketAddrs>(addr: A, ssl: Ssl) -> Result<Self, Error> {
+    pub async fn connect<A: ToSocketAddrs + std::fmt::Debug>(
+        addr: A,
+        ssl: Ssl,
+    ) -> Result<Self, Error> {
         let response_signing_keys = HmacKeys::new()?;
-        let stream = TcpStream::connect(addr).await?;
+        let stream = TcpStream::connect(&addr).await?;
+        tracing::info!(?addr, "TCP connection to the Sigul bridge established");
         let mut stream = tokio_openssl::SslStream::new(ssl, stream)?;
         Pin::new(&mut stream).connect().await?;
+        tracing::info!("TLS session with the Sigul bridge established");
 
         Ok(Connection {
             stream,


### PR DESCRIPTION
The test keys in the repository match the keys in a particular container build. Pin the container used for CI to that container rather than "latest". Now, when the container build is updated, it won't break the build. To update the version, the new keys should be extracted with `cargo xtask extract-keys` checked in and the container version should be bumped.