### PR TITLE
client: add certificate signing support

### DIFF
--- a/siguldry/CHANGELOG.md
+++ b/siguldry/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - Unreleased
+
+### Added
+
+- Added support for the `sign-certificate` command to create certificates for Sigul-managed keys (#48)
+
+
 ## [0.3.1] - 2025-06-12
 
 ### Changed


### PR DESCRIPTION
Add support for the 'sign-certificate' command to the client API.

Currently, it only supports certificates with the Common Name field, but the current sigul CLI supports just that and the Organizational Unit field, weirdly, unless you provide an RFC4514 string. This should be "good enough" for now, and a new implementation can make this less complicated.