### PR TITLE
sigul-pesign-bridge: fix docs to remove sigul client notes

### DIFF
--- a/sigul-pesign-bridge/CHANGELOG.md
+++ b/sigul-pesign-bridge/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update to siguldry v0.4 (#64)
 
+### Fixed
+
+- Removed references to the Sigul client in the documentation (#76)
+
 
 ## [0.5.0] - 2025-06-12
 

--- a/sigul-pesign-bridge/src/config.rs
+++ b/sigul-pesign-bridge/src/config.rs
@@ -120,6 +120,14 @@ pub struct Key {
     /// The name of the certificate in the Sigul server.
     pub certificate_name: String,
     /// The systemd credential ID containing the passphrase.
+    ///
+    /// The passphrase inside the file must be entirely on the first line of
+    /// the file and the file should be terminated with a newline. The default
+    /// settings for `systemd-ask-password` will produce an acceptable file:
+    ///
+    /// ```bash
+    /// systemd-ask-password | systemd-creds encrypt - /etc/credstore.encrypted/sigul.key.phrase
+    /// ```
     pub passphrase_path: PathBuf,
     /// If set, the service will validate the PE has been signed with the given
     /// certificate before returning the signed file to the client.


### PR DESCRIPTION
The bridge no longer uses the sigul client, so remove all notes about it in the README.